### PR TITLE
Provide a no-parameter creator when type is "empty"

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,8 +7,34 @@ export type Unionized<Record, TaggedRecord> = {
   match: Match<Record, TaggedRecord>
 } & Creators<Record, TaggedRecord>
 
+/*
+ * Helper types for differentiating empty parameter types ({} and null)
+ */
+export type Bool = 'T' | 'F'
+
+export type If<B extends Bool, Then, Else> = {
+  T: Then
+  F: Else
+}[B]
+
+// this is a necessary intermediate type, can't be merged into ObjectHasKeys<O>
+export type StringContains<S extends string, L extends string> = (
+  { [K in S]: { _: 'T' } } &
+  { [key: string]: { _: 'F' } }
+)[L]['_']
+
+export type ObjectHasKeys<O> = StringContains<keyof O, keyof O>
+
+/*
+ * Unionized constituents
+ */
 export type Creators<Record, TaggedRecord> = {
-  [T in keyof Record]: (value: Record[T]) => TaggedRecord[keyof TaggedRecord]
+  [T in keyof Record]:
+    If<
+      ObjectHasKeys<Record[T]>,
+      (value: Record[T]) => TaggedRecord[keyof TaggedRecord],
+      () => TaggedRecord[keyof TaggedRecord]
+    >
 }
 
 export type Predicates<TaggedRecord> = {


### PR DESCRIPTION
For "empty" types (`{}`, `void`, `null`), the `Creator` function no longer accepts an argument.

The spec for whether a type is empty is as follows:
```ts
// "T" (parameter required)
type T1 = ObjectHasKeys<1>
type T2 = ObjectHasKeys<''>
type T3 = ObjectHasKeys<true>
type T4 = ObjectHasKeys<symbol>
type T5 = ObjectHasKeys<{ foo: string }>
type T6 = ObjectHasKeys<{ foo?: string }>

// "F" (parameter not accepted)
type F1 = ObjectHasKeys<{}>
type F2 = ObjectHasKeys<null>
type F3 = ObjectHasKeys<void>
```