### PR TITLE
Added "default" case + inline usage for matching

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -35,10 +35,26 @@ describe('merged', () => {
         x: ({ n }) => n + 9,
         y: ({ s }) => s.length,
       })(foo)).toBe(12)
-      expect(Foo.match(
-        { y: ({ s }) => s.length, },
-        () => 42,
-      )(foo)).toBe(42)
+      expect(Foo.match({
+        y: ({ s }) => s.length,
+        default: () => 42
+      })(foo)).toBe(42)
+    })
+
+    it('inline matching', () => {
+      expect(Foo.match(foo, {
+        x: ({ n }) => n + 9,
+        y: ({ s }) => s.length,
+      })).toBe(12)
+      expect(Foo.match(foo, {
+        y: ({ s }) => s.length,
+        default: () => 42
+      })).toBe(42)
+    })
+
+    it('default accepts initial object', () => {
+      expect(Foo.match(foo, { default: f => f })).toBe(foo)
+      expect(Foo.match({ default: f => f })(foo)).toBe(foo)
     })
 
     describe('name conflicts', () => {
@@ -85,10 +101,26 @@ describe('separate', () => {
       x: n => n + 9,
       y: s => s.length,
     })(foo)).toBe(12)
-    expect(Foo.match(
-      { y: s => s.length, },
-      () => 42,
-    )(foo)).toBe(42)
+    expect(Foo.match({
+      y: s => s.length,
+      default: () => 42,
+    })(foo)).toBe(42)
+  })
+
+  it('inline matching', () => {
+    expect(Foo.match(foo, {
+      x: n => n + 9,
+      y: s => s.length,
+    })).toBe(12)
+    expect(Foo.match(foo, {
+      y: s => s.length,
+      default: () => 42,
+    })).toBe(42)
+  })
+
+  it('default accepts initial object', () => {
+    expect(Foo.match(foo, { default: f => f })).toBe(foo)
+    expect(Foo.match({ default: f => f })(foo)).toBe(foo)
   })
 
   it('enumerable tags', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -101,6 +101,8 @@ export function unionize<Record>(record: Record, tagProp = 'tag', valProp?: stri
     const k = variant[tagProp]
     return k in cases
       ? cases[k](valProp ? variant[valProp] : variant)
+      // here we can have '"undefined is not a function". Is it worth checking?
+      // it is <impossible> to get in ts but totally fine in js land
       : cases.default(variant)
   }
 


### PR DESCRIPTION
This is a step 1 and 1.1 of https://github.com/pelotom/unionize/issues/18

Concerns/comments:
1) It is a breaking change because of "default".
2) I used match(...args) {} for checking number of arguments. This is being transpiled to args[0] = arguments[0]. Which is an extra allocation of a new array for args every time match is called. What is the best practice here? Use (...args[]) vs arguments object? There is no arguments object in arrow functions as far as I know, which is a downside of arguments I suppose?
3) I removed the fallback function which was initialized as v => undefined. It means that if you cheat on types and pass incomplete match cases you will have undefined as a result with no exception. I do believe that it is better to throw an exception if somebody hacked ts. Not 100% of a proper way to handle that.
4) I didn't change readme.md. I think it makes sense to do that right before publishing to npm?