### PR TITLE
support for inline matching

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -44,6 +44,21 @@ describe('merged', () => {
     ).toBe(42);
   });
 
+  it('inline matching', () => {
+    expect(
+      Foo.match(foo, {
+        x: ({ n }) => n + 9,
+        y: ({ s }) => s.length,
+      }),
+    ).toBe(12);
+    expect(
+      Foo.match(foo, {
+        y: ({ s }) => s.length,
+        default: _ => 42,
+      }),
+    ).toBe(42);
+  });
+
   it('accepts undefined props with default for matching', () => {
     expect(
       Foo.match({
@@ -56,6 +71,7 @@ describe('merged', () => {
 
   it('default accepts initial object for matching', () => {
     expect(Foo.match({ default: f => f })(foo)).toBe(foo);
+    expect(Foo.match(foo, { default: f => f })).toBe(foo);
   });
 
   describe('name conflicts', () => {
@@ -119,6 +135,22 @@ describe('separate', () => {
     ).toBe(42);
   });
 
+  it('inline matching', () => {
+    expect(
+      Foo.match(foo, {
+        x: n => n + 9,
+        y: s => s.length,
+      }),
+    ).toBe(12);
+
+    expect(
+      Foo.match(foo, {
+        y: s => s.length,
+        default: _ => 42,
+      }),
+    ).toBe(42);
+  });
+
   it('accepts undefined props with default for matching', () => {
     expect(
       Foo.match({
@@ -131,6 +163,7 @@ describe('separate', () => {
 
   it('default accepts initial object for matching', () => {
     expect(Foo.match({ default: f => f })(foo)).toBe(foo);
+    expect(Foo.match(foo, { default: f => f })).toBe(foo);
   });
 
   it('enumerable tags', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,7 +95,8 @@ export function unionize<Record>(record: Record, tagProp = 'tag', valProp?: stri
       : cases.default(variant);
   }
 
-  const match: ReverseCurriedFunc<any, any, any> = reverseCurry(evalMatch);
+  const match = (first: any, second?: any) =>
+    second ? evalMatch(first, second) : (variant: any) => evalMatch(variant, first);
 
   const as = {} as Casts<Record, any>;
   for (const expectedTag in record) {
@@ -116,25 +117,6 @@ export function unionize<Record>(record: Record, tagProp = 'tag', valProp?: stri
     },
     creators,
   );
-}
-
-type ReverseCurriedFunc<A1, A2, R> = {
-  (a1: A1, a2: A2): R;
-  (a2: A2): (a1: A1) => R;
-};
-
-function reverseCurry<A1, A2, R, F extends (a1: A1, a2: A2) => R>(
-  f: F,
-): ReverseCurriedFunc<A1, A2, R> {
-  const func = function reverseCurried(a1: A1 | A2, a2: A2 | undefined) {
-    if (arguments.length == 1) {
-      return (a: A1) => f(a, <A2>a1);
-    }
-
-    return f(<A1>a1, <A2>a2);
-  };
-
-  return (func as any) as ReverseCurriedFunc<A1, A2, R>;
 }
 
 /**


### PR DESCRIPTION
* Added reverseCurry function that is based on number of arguments + works via arguments
```typescript
function reverseCurry<A1, A2, R, F extends (a1: A1, a2: A2) => R>(
  f: F,
): ReverseCurriedFunc<A1, A2, R> {
  const func = function reverseCurried(a1: A1 | A2, a2: A2 | undefined) {
    if (arguments.length == 1) {
      return (a: A1) => f(a, <A2>a1);
    }

    return f(<A1>a1, <A2>a2);
  };

  return (func as any) as ReverseCurriedFunc<A1, A2, R>;
}
```
* Also replaced match with evalMatch -> reverseCurry(evalMatch)
* Added tests for inline matching
