### PR TITLE
added config object. for now only supports tag & val props

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -80,7 +80,7 @@ describe('merged', () => {
         {
           foo: ofType<{ x: number }>(),
         },
-        { tagProp: 'conflict' },
+        { tag: 'conflict' },
       );
       const input = { x: 42, conflict: 'oops' };
       expect(T.foo(input).conflict).toBe('foo');
@@ -94,7 +94,7 @@ describe('separate', () => {
       x: ofType<number>(),
       y: ofType<string>(),
     },
-    { tagProp: 'flim', valProp: 'flam' },
+    { tag: 'flim', value: 'flam' },
   );
 
   let foo: typeof Foo._Union;
@@ -172,7 +172,7 @@ describe('separate', () => {
         y: ofType<string>(),
         z: ofType<boolean>(),
       },
-      { tagProp: 'blum', valProp: 'blam' },
+      { tag: 'blum', value: 'blam' },
     );
 
     const bar = Foo.match(Bar)(foo);
@@ -187,7 +187,7 @@ describe('spreads', () => {
       fred: ofType<string>(),
       wilma: ofType<string>(),
     },
-    { tagProp: 'name', valProp: 'catchphrase' },
+    { tag: 'name', value: 'catchphrase' },
   );
 
   const Flintstones = unionize(
@@ -195,7 +195,7 @@ describe('spreads', () => {
       pebbles: ofType<string>(),
       ...Parents._Record,
     },
-    { tagProp: 'name', valProp: 'catchphrase' },
+    { tag: 'name', value: 'catchphrase' },
   );
 
   let fred: typeof Flintstones._Union;
@@ -255,10 +255,10 @@ describe('spreads', () => {
 
   // note: TagProp and ValProp of spreaded _Record has no signficance on final record
   it('creation with different TagProp and ValProp', () => {
-    const foo = unionize({ a: ofType<{ x: number }>() }, { tagProp: 'type', valProp: 'payload' });
+    const foo = unionize({ a: ofType<{ x: number }>() }, { tag: 'type', value: 'payload' });
     const bar = unionize(
       { b: ofType<{ y: string }>(), ...foo._Record },
-      { tagProp: 'schmype', valProp: 'schmayload' },
+      { tag: 'schmype', value: 'schmayload' },
     );
 
     expect(bar.a({ x: 1 })).toEqual({
@@ -270,5 +270,12 @@ describe('spreads', () => {
       schmype: 'b',
       schmayload: { y: 'qwertz' },
     });
+  });
+});
+
+describe('config object', () => {
+  it('can have only value prop', () => {
+    const A = unionize({ a: ofType<number>() }, { value: 'val' });
+    expect(A.a(1)).toEqual({ tag: 'a', val: 1 });
   });
 });

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -80,7 +80,7 @@ describe('merged', () => {
         {
           foo: ofType<{ x: number }>(),
         },
-        'conflict',
+        { tagProp: 'conflict' },
       );
       const input = { x: 42, conflict: 'oops' };
       expect(T.foo(input).conflict).toBe('foo');
@@ -94,8 +94,7 @@ describe('separate', () => {
       x: ofType<number>(),
       y: ofType<string>(),
     },
-    'flim',
-    'flam',
+    { tagProp: 'flim', valProp: 'flam' },
   );
 
   let foo: typeof Foo._Union;
@@ -173,8 +172,7 @@ describe('separate', () => {
         y: ofType<string>(),
         z: ofType<boolean>(),
       },
-      'blum',
-      'blam',
+      { tagProp: 'blum', valProp: 'blam' },
     );
 
     const bar = Foo.match(Bar)(foo);
@@ -189,8 +187,7 @@ describe('spreads', () => {
       fred: ofType<string>(),
       wilma: ofType<string>(),
     },
-    'name',
-    'catchphrase',
+    { tagProp: 'name', valProp: 'catchphrase' },
   );
 
   const Flintstones = unionize(
@@ -198,8 +195,7 @@ describe('spreads', () => {
       pebbles: ofType<string>(),
       ...Parents._Record,
     },
-    'name',
-    'catchphrase',
+    { tagProp: 'name', valProp: 'catchphrase' },
   );
 
   let fred: typeof Flintstones._Union;
@@ -259,8 +255,11 @@ describe('spreads', () => {
 
   // note: TagProp and ValProp of spreaded _Record has no signficance on final record
   it('creation with different TagProp and ValProp', () => {
-    const foo = unionize({ a: ofType<{ x: number }>() }, 'type', 'payload');
-    const bar = unionize({ b: ofType<{ y: string }>(), ...foo._Record }, 'schmype', 'schmayload');
+    const foo = unionize({ a: ofType<{ x: number }>() }, { tagProp: 'type', valProp: 'payload' });
+    const bar = unionize(
+      { b: ofType<{ y: string }>(), ...foo._Record },
+      { tagProp: 'schmype', valProp: 'schmayload' },
+    );
 
     expect(bar.a({ x: 1 })).toEqual({
       schmype: 'a',

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,14 +66,14 @@ export function unionize<
   ValProp extends string
 >(
   record: Record,
-  config: { valProp: ValProp; tagProp?: TagProp },
+  config: { value: ValProp; tag?: TagProp },
 ): Unionized<Record, SingleValueVariants<Record, TagProp, ValProp>>;
 export function unionize<Record extends MultiValueRec, TagProp extends string>(
   record: Record,
-  config?: { tagProp: TagProp },
+  config?: { tag: TagProp },
 ): Unionized<Record, MultiValueVariants<Record, TagProp>>;
-export function unionize<Record>(record: Record, config?: { valProp?: string; tagProp?: string }) {
-  const { valProp = undefined, tagProp = 'tag' } = config || {};
+export function unionize<Record>(record: Record, config?: { value?: string; tag?: string }) {
+  const { value: valProp = undefined, tag: tagProp = 'tag' } = config || {};
 
   const creators = {} as Creators<Record, any>;
   for (const tag in record) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,23 +59,22 @@ export type NoDefaultRec<Val> = {
  * @param valProp An optional custom name for the value property of the union. If not specified,
  * the value must be a dictionary type.
  */
-export function unionize<Record extends MultiValueRec>(
-  record: Record,
-): Unionized<Record, MultiValueVariants<Record, 'tag'>>;
-export function unionize<Record extends MultiValueRec, TagProp extends string>(
-  record: Record,
-  tagProp: TagProp,
-): Unionized<Record, MultiValueVariants<Record, TagProp>>;
+
 export function unionize<
   Record extends SingleValueRec,
   TagProp extends string,
   ValProp extends string
 >(
   record: Record,
-  tagProp: TagProp,
-  valProp: ValProp,
+  config: { valProp: ValProp; tagProp?: TagProp },
 ): Unionized<Record, SingleValueVariants<Record, TagProp, ValProp>>;
-export function unionize<Record>(record: Record, tagProp = 'tag', valProp?: string) {
+export function unionize<Record extends MultiValueRec, TagProp extends string>(
+  record: Record,
+  config?: { tagProp: TagProp },
+): Unionized<Record, MultiValueVariants<Record, TagProp>>;
+export function unionize<Record>(record: Record, config?: { valProp?: string; tagProp?: string }) {
+  const { valProp = undefined, tagProp = 'tag' } = config || {};
+
   const creators = {} as Creators<Record, any>;
   for (const tag in record) {
     creators[tag] = (value: any) =>


### PR DESCRIPTION
* NOTE: this is yet another breaking change.
* This PR introduces optional config object instead of extra arguments for 'unionize'.
* Note I was unable to add 'namespace' prop with proper ts support
```typescript
const a = 'a'; // type === 'a'
const b = 'b'; // type === 'b'
const c = a+b; // type === string :( not 'ab'
```
Note that we can add a property but not concat namespace + key. So, as far as I know 
type = {tag:'[TODO] ADD'; payload: string} is not possible atm.

That said, I still think this is a useful change. It gives freedom to extend api if necessary by adding other props to config object.

* not sure about property names though. 
```typescript
{ tagProp: 'type', valProp: 'payload' }
// vs
{ tag: 'type', val: 'payload' }
``` 
At the moment this PR uses tagProp & valProp prop names