### PR TITLE
Added transofrm function (instead of update)

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -279,3 +279,48 @@ describe('config object', () => {
     expect(A.a(1)).toEqual({ tag: 'a', val: 1 });
   });
 });
+
+describe('update suite', () => {
+  const Paylod = unionize(
+    {
+      num: ofType<number>(),
+      str: ofType<string>(),
+    },
+    { value: 'payload' },
+  );
+
+  it('skips unmet cases', () => {
+    const num = Paylod.num(1);
+    expect(Paylod.update(num, { str: s => s + '?' })).toBe(num);
+    expect(Paylod.update({ str: s => s + '??' })(num)).toBe(num);
+  });
+
+  it('updates with met cases', () => {
+    const str = Paylod.str('hi');
+    const exclaim = (s: string) => s + '!';
+    const exclaimed = Paylod.str('hi!');
+    expect(Paylod.update({ str: exclaim })(str)).toEqual(exclaimed);
+    expect(Paylod.update(str, { str: exclaim })).toEqual(exclaimed);
+  });
+
+  it('updates immutably by partial state', () => {
+    const Data = unionize({
+      A: ofType<{ a: 'not used' }>(),
+      BC: ofType<{ b: number; c: string }>(),
+    });
+
+    const bc = Object.freeze(Data.BC({ b: 1, c: 'hi' }));
+    const expected = Data.BC({ b: 1, c: 'hi!' });
+    expect(Data.update({ BC: ({ c }) => ({ c: c + '!' }) })(bc)).toEqual(expected);
+    expect(Data.update(bc, { BC: ({ c }) => ({ c: c + '!' }) })).toEqual(expected);
+  });
+
+  it('still updated even with value prop', () => {
+    const Data = unionize({ BC: ofType<{ b: number; c: string }>() }, { value: 'payload' });
+
+    const bc = Object.freeze(Data.BC({ b: 1, c: 'hi' }));
+    const expected = Data.BC({ b: 1, c: 'hi!' });
+    expect(Data.update({ BC: ({ c }) => ({ c: c + '!' }) })(bc)).toEqual(expected);
+    expect(Data.update(bc, { BC: ({ c }) => ({ c: c + '!' }) })).toEqual(expected);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,13 +73,13 @@ export type NoDefaultRec<Val> = {
 
 export function unionize<
   Record extends SingleValueRec,
-  TagProp extends string,
-  ValProp extends string
+  ValProp extends string,
+  TagProp extends string = 'tag'
 >(
   record: Record,
   config: { value: ValProp; tag?: TagProp },
 ): Unionized<Record, SingleValueVariants<Record, TagProp, ValProp>>;
-export function unionize<Record extends MultiValueRec, TagProp extends string>(
+export function unionize<Record extends MultiValueRec, TagProp extends string = 'tag'>(
   record: Record,
   config?: { tag: TagProp },
 ): Unionized<Record, MultiValueVariants<Record, TagProp>>;


### PR DESCRIPTION
* This PR allows to conveniently work with redux states modeled with unionize.
* update takes an object and update cases. If the cases are unmet the original object is returned
* If there is a met case the result of it is either merged to the object or replaced. It has Partial<T> signature for update result. So strings, numbers, Dates are being replaced and plain objects merged in.
* this is done via the most brilliant api possible
```typescript
// Should we merge objects or just replace them?
// was unable to find a better solution to that
const objType = Object.prototype.toString.call({}); // [object Object]
const isObject = (maybeObj: any) => Object.prototype.toString.call(maybeObj) === objType;
const immutableUpd = (old: any, updated: any) =>
  isObject(old) ? Object.assign({}, old, updated) : updated;
```
Do have any ideas how to achieve it differently?
* For me personally this is probably one of the most needed changes. I use unionize only for redux states.
```typescript
const Data = unionize({AB: ofType<{ a: number; b: string }>()});
const ab = Data.AB({ a: 1, b: 'hi' });
Data.update(ab, { AB: ({ b }) => ({ b: b + '!' }) }); // {tag:'AB', a: 1, b: 'hi!'}
```