### PR TITLE
Make creation function argument optional for variants of type {}

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,10 @@ import { unionize, ofType } from 'unionize'
 
 // Define a record mapping tag literals to value types
 const Action = unionize({
-  ADD_TODO:                ofType<{ id: string; text: string }>(),
-  SET_VISIBILITY_FILTER:   ofType<'SHOW_ALL' | 'SHOW_ACTIVE' | 'SHOW_COMPLETED'>(),
-  TOGGLE_TODO:             ofType<{ id: string }>()
+  ADD_TODO: ofType<{ id: string; text: string }>(),
+  SET_VISIBILITY_FILTER: ofType<'SHOW_ALL' | 'SHOW_ACTIVE' | 'SHOW_COMPLETED'>(),
+  TOGGLE_TODO: ofType<{ id: string }>(),
+  CLEAR_TODOS: {}, // For "empty" types, just use {}
 },
   // optionally override tag and/or value property names
   {
@@ -39,6 +40,7 @@ type Action =
   | { type: ADD_TODO; payload: { id: string; text: string } }
   | { type: SET_VISIBILITY_FILTER; payload: 'SHOW_ALL' | 'SHOW_ACTIVE' | 'SHOW_COMPLETED' }
   | { type: TOGGLE_TODO; payload: { id: string } }
+  | { type: CLEAR_TODOS; payload: {} }
 ```
 
 Having done that, you now have at your disposal:
@@ -48,6 +50,7 @@ Having done that, you now have at your disposal:
 ```ts
 store.dispatch(Action.ADD_TODO({ id: 'c819bbc1', text: 'Take out the trash' }));
 store.dispatch(Action.SET_VISIBILITY_FILTER('SHOW_COMPLETED'));
+store.dispatch(Action.CLEAR_TODOS()); // no argument required if value type is {}
 ```
 
 #### Match expressions

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -4,6 +4,7 @@ describe('merged', () => {
   const Foo = unionize({
     x: ofType<{ n: number }>(),
     y: ofType<{ s: string }>(),
+    z: ofType<{}>(),
   });
 
   let foo: typeof Foo._Union;
@@ -17,6 +18,7 @@ describe('merged', () => {
       tag: 'x',
       n: 3,
     });
+    expect(Foo.z()).toEqual(Foo.z({}));
   });
 
   it('predicates', () => {
@@ -34,6 +36,7 @@ describe('merged', () => {
       Foo.match({
         x: ({ n }) => n + 9,
         y: ({ s }) => s.length,
+        z: () => 42,
       })(foo),
     ).toBe(12);
     expect(
@@ -49,6 +52,7 @@ describe('merged', () => {
       Foo.match(foo, {
         x: ({ n }) => n + 9,
         y: ({ s }) => s.length,
+        z: () => 42,
       }),
     ).toBe(12);
     expect(

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,9 @@ export type Unionized<Record, TaggedRecord> = {
 } & Creators<Record, TaggedRecord>;
 
 export type Creators<Record, TaggedRecord> = {
-  [T in keyof Record]: (value: Record[T]) => TaggedRecord[keyof TaggedRecord]
+  [T in keyof Record]: {} extends Record[T]
+    ? ((value?: {}) => TaggedRecord[keyof TaggedRecord])
+    : ((value: Record[T]) => TaggedRecord[keyof TaggedRecord])
 };
 
 export type Predicates<TaggedRecord> = {
@@ -88,8 +90,8 @@ export function unionize<Record>(record: Record, config?: { value?: string; tag?
 
   const creators = {} as Creators<Record, any>;
   for (const tag in record) {
-    creators[tag] = (value: any) =>
-      valProp ? { [tagProp]: tag, [valProp]: value } : { ...value, [tagProp]: tag };
+    creators[tag] = ((value = {}) =>
+      valProp ? { [tagProp]: tag, [valProp]: value } : { ...value, [tagProp]: tag }) as any;
   }
 
   const is = {} as Predicates<any>;


### PR DESCRIPTION
Resolves #30 (reimplementation of #15 using conditional types).

Unlike in that proposal, this doesn't work for `void`, `null`, or any other type than `{}`. The reason for this is that `{}` is the only unit type which works for both "merged"/"multi-valued" and "separate"/"single-valued" kinds of unions. It doesn't seem feasible in a simple way to allow more than one unit type to trigger this behavior.