### PR TITLE
Allow including tag in value type

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -90,6 +90,19 @@ describe('merged', () => {
       expect(T.foo(input).conflict).toBe('foo');
     });
   });
+
+  describe('can define an interface tag', () => {
+    it('generate a type without an intersection', () => {
+      interface Foo {
+        tag: 'foo';
+        x: number;
+      }
+      const T = unionize({
+        foo: ofType<Foo>(),
+      });
+      expect(T.foo({ x: 42 }).tag).toBe('foo');
+    });
+  });
 });
 
 describe('separate', () => {


### PR DESCRIPTION
Resolves #35.

It removes useless intersection in case a tag is already provided as part of the type

