### PR TITLE
Don't flatten union-type values through `UnTagged`

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -358,3 +358,16 @@ describe('type accessors', () => {
     });
   });
 });
+
+describe('separate with union value', () => {
+  const Foo = unionize(
+    {
+      union: ofType<{ status: 'a' } | { status: 'b'; payload: string }>(),
+    },
+    { tag: 'not_tag', value: 'value' },
+  );
+
+  it('creation', () => {
+    Foo.union({ status: 'b', payload: 'something' });
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,10 +61,9 @@ export type MultiValueVariants<Record extends MultiValueRec, TagProp extends str
     : { [_ in TagProp]: T } & Record[T] // no: decorate with tag
 };
 
-export type UnTagged<Record, TagProp extends string = 'tag'> = Pick<
-  Record,
-  { [k in keyof Record]: k extends TagProp ? never : k }[keyof Record]
->;
+export type UnTagged<Record, TagProp extends string = 'tag'> = Record extends {}
+  ? Pick<Record, { [k in keyof Record]: k extends TagProp ? never : k }[keyof Record]>
+  : never;
 
 export type SingleValueVariants<
   Record extends SingleValueRec,


### PR DESCRIPTION
This fixes an issue where union-type values are "flattened" by `UnTagged`, dropping any fields which aren't shared by every element of the union. This results in an incorrect type for the creator function argument.

```
const Foo = unionize(
  {
    union: ofType<{ status: 'a' } | { status: 'b'; payload: string }>(),
  },
  { tag: 'not_tag', value: 'value' }, // only triggered when tag is not the default of 'tag'
);

Foo.union({ status: 'b' }); // ok (should fail)
Foo.union({ status: 'b', payload: 'something' }); // error: can only specify known properties
```