### PR TITLE
Expose `TaggedRecord`

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1,4 +1,4 @@
-import { ofType, unionize, UnionOf, Unionized } from '.';
+import { ofType, unionize, UnionOf, TaggedRecordOf, Unionized } from '.';
 
 describe('merged', () => {
   const Foo = unionize({
@@ -342,6 +342,14 @@ describe('type accessors', () => {
         foo: ofType<{ x: number }>(),
       });
       type ActionType = UnionOf<typeof T>;
+    });
+  });
+  describe('TaggedRecordOf', () => {
+    it('should be usable', () => {
+      const T = unionize({
+        foo: ofType<{ x: number }>(),
+      });
+      type TaggedRecord = TaggedRecordOf<typeof T>;
     });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ export type Unionized<Record, TaggedRecord, TagProp extends string> = UnionTypes
   UnionExtensions<Record, TaggedRecord>;
 
 export interface UnionTypes<Record, TaggedRecord> {
+  _TaggedRecord: TaggedRecord;
   _Tags: keyof TaggedRecord;
   _Record: Record;
   _Union: TaggedRecord[keyof TaggedRecord];
@@ -17,6 +18,7 @@ export interface UnionExtensions<Record, TaggedRecord> {
   transform: Transform<Record, TaggedRecord[keyof TaggedRecord]>;
 }
 
+export type TaggedRecordOf<U extends UnionTypes<any, any>> = U['_TaggedRecord'];
 export type TagsOf<U extends UnionTypes<any, any>> = U['_Tags'];
 export type RecordOf<U extends UnionTypes<any, any>> = U['_Record'];
 export type UnionOf<U extends UnionTypes<any, any>> = U['_Union'];


### PR DESCRIPTION
This would be useful when defining custom predicates, e.g.

```ts
const T = unionize({
  foo: ofType<{ x: number }>(),
});
type ActionType = UnionOf<typeof T>;
type TaggedRecord = TaggedRecordOf<typeof T>;

const isFooAndXIs1 = (action: ActionType): action is TaggedRecord['foo'] =>
  T.is.foo(action) && action.x === 1;
```