### PR TITLE
Expose record tags as string constants

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -366,3 +366,15 @@ describe('separate with union value', () => {
     Foo.union({ status: 'b', payload: 'something' });
   });
 });
+
+describe('record tags', () => {
+  const LightBulb = unionize({
+    ON: ofType<{ dimLevel: number }>(),
+    OFF: ofType<{}>(),
+  });
+
+  it('should allow to access the tags', () => {
+    expect(LightBulb.tags.ON).toBe('ON');
+    expect(LightBulb.tags.OFF).toBe('OFF');
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ export interface UnionTypes<Record, TaggedRecord> {
 export interface UnionExtensions<Record, TaggedRecord> {
   is: Predicates<TaggedRecord>;
   as: Casts<Record, TaggedRecord[keyof TaggedRecord]>;
+  tags: TagRecord<Record>;
   match: Match<Record, TaggedRecord[keyof TaggedRecord]>;
   transform: Transform<Record, TaggedRecord[keyof TaggedRecord]>;
 }
@@ -56,6 +57,8 @@ export interface Transform<Record, Union> {
   (cases: TransformCases<Record, Union>): (variant: Union) => Union;
   (variant: Union, cases: TransformCases<Record, Union>): Union;
 }
+
+export type TagRecord<Record> = { [T in keyof Record]: T };
 
 export type MultiValueVariants<Record extends MultiValueRec<TagProp>, TagProp extends string> = {
   [T in keyof Record]: Record[T] extends { [_ in TagProp]: T } // does record already has tag with correct value?
@@ -144,10 +147,16 @@ export function unionize<Record>(record: Record, config?: { value?: string; tag?
     });
   }
 
+  const tags = {} as TagRecord<Record>;
+  for (const tag in record) {
+    tags[tag] = tag;
+  }
+
   return Object.assign(
     {
       is,
       as,
+      tags,
       match,
       transform,
       _Record: record,


### PR DESCRIPTION
Adresses #75 .

**Motivation**
When interfacing with other libraries/other code, there is sometimes a need for for using the tags from the tagged union. This results in need to define our unions as follows, which is unnecessarily verbose and boilerplateful.
```typescript
const ON = 'ON';
const OFF = 'OFF';

const State = unionized({
  [ON]: ofType<{}>(),
  [OFF]: ofType<{}>()
})

// do something later with tag
console.log(ON)  // 'ON'
```

**Solution**
Expose record tags as a property on the `Unionized` object.

```typescript
const State = unionized({
  ON: ofType<{}>(),
  OFF: ofType<{}>()
})

// do something later with tag
console.log(State.tags.ON)  // 'ON'

/*
State.tags is:
{
  ON: 'ON';
  OFF: 'OFF';
}
*/
```